### PR TITLE
Allow passing of custom activity map + minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,22 @@ This will show you the usage.
 
 ### Converting a CSV into a set of _fit_ files
 
-```java -jar fitnotes2fit.jar convert -i <path/to/file.csv> [-o <optional/output/dir/>] [-hr <average heartrate>] [-rt <average rest time (in minutes)>]```
+```java -jar fitnotes2fit.jar convert -i <path/to/file.csv> [-o <optional/output/dir/>] [-hr <average heartrate>] [-rt <average rest time (in minutes)>] [-m "<FitNotes exercise name>"=<FIT Exercise name>,"<FitNotes exercise name 2>"=<FIT Exercise name 2>,...]```
 
 - This will take the csv provided by `-i <path/to/file.csv>`, and will convert it to a set of fit files, one for each workout (distinguished by the _Date_ column in the csv).
 
 - The optional argument `-o <optional/output/dir/>` specifies the output folder. Otherwise the current directory will be used.
 
+- This tool supports a limited set of exercises (not including all of the default exercises in FitNotes) The optional argument `-m "<FitNotes exercise name>"=<FIT Exercise name>,...` adds exercises to the list of available mappings. Use this to ensure that all your exercises are mappable. Use the `list_exercises` command to understand the list of possible FIT exercise names.
+
 - The other two optional arguments are for "advanced" usage. If provided an average heart-rate, using `-hr <average heartrate>`, the converter will generate a set of "heart-rate-monitor" records around that average, and encode them within the output workouts.
 
 - Average rest time in minutes (e.g. 1.5) can be provided with `-rt <average rest time>`. If provided, a random rest around that time (plus minus 1 minute) will be generated for each set. This helps with encoding a more appropriate time for the workout, which is useful for example in Strava, where the Relative Effort metric uses the heart-rate and time of activity to be calculated.
+
+### Listing all possible FIT exercise names
+
+```java -jar fitnotes2fit.jar list_exercises```
+
 
 # For developers
 ## Building for yourself
@@ -51,9 +58,7 @@ Since the package relies on FitSDK, and the SDK is not available in any reposito
 
 ### Important limitations
 
-* Currently the one big problem, is that not all default exercises provided by FitNotes are being encoded in the fit category system. At least the defaults will be implemented soon enough. In the log of running the converter, these uncategorised exercises are mentioned.
-
-* This leaves the issue with customly-added to FitNotes exercises. For now, this is not the focus of development, but some possible user input option is conceivable.
+* Not all default FitNotes exercises are supported out of the box. In the log of running the converter, these uncategorised exercises are mentioned. It is up to the user to provide mappings from the FitNotes exercise names to `Fit` exercise names. Check out the `list_exercises` command and the `--mappings` option of the `convert` command to understand how. This also allows you to map non-default exercises from FitNotes.
 
 ## Readme TODO
 

--- a/src/main/java/com/developination/fitnotes2fit/FitNotesParser/FitNotesParser.java
+++ b/src/main/java/com/developination/fitnotes2fit/FitNotesParser/FitNotesParser.java
@@ -181,50 +181,8 @@ public class FitNotesParser {
     return map;
   }
 
-
-  /**
-   * Parses a FitNotes CSV file, and creates a list of Activities encodable into the FIT format
-   *
-   * @param filepath
-   * @return List<Activity>
-   * @throws Exception
-   */
-  public List<Activity> parseFileNotesIntoActivities(String filepath) throws Exception {
+  private List<Activity> _parseFileNotesIntoActivities(List<FitNotesSet> setsList) throws Exception {
     List<Activity> result = new ArrayList<>();
-    List<FitNotesSet> setsList = readFileNotesSets(filepath);
-    Map<String, List<ActivitySet>> mapDateToSets = new HashMap<>();
-
-    for (FitNotesSet singleSet : setsList) {
-      ActivitySet parsedSet = convertFromFitNotesSet(singleSet);
-
-      if (mapDateToSets.containsKey(singleSet.getDate())) {
-        mapDateToSets.get(singleSet.getDate()).add(parsedSet);
-      } else {
-        List<ActivitySet> newList = new ArrayList<>(1);
-        newList.add(parsedSet);
-        mapDateToSets.put(singleSet.getDate(), newList);
-      }
-    }
-
-    for (Map.Entry<String, List<ActivitySet>> mapEntry : mapDateToSets.entrySet()) {
-      Activity activity = new Activity(
-        DataConverter.convertDateTime(mapEntry.getKey()), mapEntry.getValue());
-      result.add(activity);
-    }
-
-    return result;
-  }
-
-  /**
-   * Parses a FitNotes CSV file, and creates a list of Activities encodable into the FIT format
-   *
-   * @param fileContent
-   * @return List<Activity>
-   * @throws Exception
-   */
-  public List<Activity> parseFileNotesIntoActivities(byte[] fileContent) throws Exception {
-    List<Activity> result = new ArrayList<>();
-    List<FitNotesSet> setsList = readFileNotesSets(fileContent);
     Map<String, List<ActivitySet>> mapDateToSets = new HashMap<>();
 
     for (FitNotesSet singleSet : setsList) {
@@ -246,6 +204,32 @@ public class FitNotesParser {
     }
 
     return result;
+  }
+
+
+  /**
+   * Parses a FitNotes CSV file, and creates a list of Activities encodable into the FIT format
+   *
+   * @param filepath
+   * @return List<Activity>
+   * @throws Exception
+   */
+  public List<Activity> parseFileNotesIntoActivities(String filepath) throws Exception {
+    List<FitNotesSet> setsList = readFileNotesSets(filepath);
+    return _parseFileNotesIntoActivities(setsList);
+  }
+
+  /**
+   * Parses a FitNotes CSV file, and creates a list of Activities encodable into the FIT format
+   *
+   * @param fileContent
+   * @return List<Activity>
+   * @throws Exception
+   */
+
+  public List<Activity> parseFileNotesIntoActivities(byte[] fileContent) throws Exception {
+    List<FitNotesSet> setsList = readFileNotesSets(fileContent);
+    return _parseFileNotesIntoActivities(setsList);
   }
 
 
@@ -272,16 +256,7 @@ public class FitNotesParser {
     return result;
   }
 
-
-  /**
-   * Reads a FitNotes csv file into a list of FitNotes sets
-   *
-   * @param filepath
-   * @return List<FitNotesSet>
-   * @throws Exception
-   */
-  public static List<FitNotesSet> readFileNotesSets(String filepath) throws Exception {
-    Reader reader = new BufferedReader(new FileReader(filepath));
+  private static List<FitNotesSet> _readFileNotesSets(Reader reader) throws Exception {
     CsvToBean<FitNotesSet> csvReader = new CsvToBeanBuilder<FitNotesSet>(reader)
                 .withType(FitNotesSet.class)
                 .withIgnoreLeadingWhiteSpace(true)
@@ -296,21 +271,25 @@ public class FitNotesParser {
   /**
    * Reads a FitNotes csv file into a list of FitNotes sets
    *
+   * @param filepath
+   * @return List<FitNotesSet>
+   * @throws Exception
+   */
+  public static List<FitNotesSet> readFileNotesSets(String filepath) throws Exception {
+    Reader reader = new BufferedReader(new FileReader(filepath));
+    return _readFileNotesSets(reader);
+  }
+
+  /**
+   * Reads a FitNotes csv file into a list of FitNotes sets
+   *
    * @param fileContent
    * @return List<FitNotesSet>
    * @throws Exception
    */
   public static List<FitNotesSet> readFileNotesSets(byte[] fileContent) throws Exception {
     Reader reader = new StringReader(new String(fileContent));
-    CsvToBean<FitNotesSet> csvReader = new CsvToBeanBuilder<FitNotesSet>(reader)
-            .withType(FitNotesSet.class)
-            .withIgnoreLeadingWhiteSpace(true)
-            .withSeparator(',')
-            .withIgnoreLeadingWhiteSpace(true)
-            .build();
-    List<FitNotesSet> list = csvReader.parse();
-    reader.close();
-    return list;
+    return _readFileNotesSets(reader);
   }
 
 }

--- a/src/main/java/com/developination/fitnotes2fit/FitNotesParser/FitNotesParser.java
+++ b/src/main/java/com/developination/fitnotes2fit/FitNotesParser/FitNotesParser.java
@@ -4,7 +4,9 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,9 @@ import com.developination.fitnotes2fit.models.FitNotesSet;
 import com.developination.fitnotes2fit.util.DataConverter;
 import com.garmin.fit.BenchPressExerciseName;
 import com.garmin.fit.CalfRaiseExerciseName;
+import com.garmin.fit.CardioExerciseName;
+import com.garmin.fit.CarryExerciseName;
+import com.garmin.fit.ChopExerciseName;
 import com.garmin.fit.CoreExerciseName;
 import com.garmin.fit.CrunchExerciseName;
 import com.garmin.fit.CurlExerciseName;
@@ -22,57 +27,159 @@ import com.garmin.fit.DeadliftExerciseName;
 import com.garmin.fit.ExerciseCategory;
 import com.garmin.fit.FlyeExerciseName;
 import com.garmin.fit.HipRaiseExerciseName;
+import com.garmin.fit.HipStabilityExerciseName;
+import com.garmin.fit.HipSwingExerciseName;
+import com.garmin.fit.HyperextensionExerciseName;
 import com.garmin.fit.LateralRaiseExerciseName;
+import com.garmin.fit.LegCurlExerciseName;
+import com.garmin.fit.LegRaiseExerciseName;
 import com.garmin.fit.LungeExerciseName;
+import com.garmin.fit.OlympicLiftExerciseName;
+import com.garmin.fit.PlankExerciseName;
+import com.garmin.fit.PlyoExerciseName;
 import com.garmin.fit.PullUpExerciseName;
+import com.garmin.fit.PushUpExerciseName;
 import com.garmin.fit.RowExerciseName;
+import com.garmin.fit.RunExerciseName;
 import com.garmin.fit.ShoulderPressExerciseName;
 import com.garmin.fit.ShoulderStabilityExerciseName;
+import com.garmin.fit.ShrugExerciseName;
+import com.garmin.fit.SitUpExerciseName;
 import com.garmin.fit.SquatExerciseName;
+import com.garmin.fit.TotalBodyExerciseName;
 import com.garmin.fit.TricepsExtensionExerciseName;
+import com.garmin.fit.WarmUpExerciseName;
 import com.opencsv.bean.CsvToBean;
 import com.opencsv.bean.CsvToBeanBuilder;
 
 public class FitNotesParser {
 
-  public FitNotesParser () {
+  private Map<String, int[]> exercise_to_fit_category_map = new HashMap<>();
+  private Map<String, int[]> FITStringToFITIndices;
+
+  /**
+   * Class to parse a FitNotes CSV file into activities in FIT format.
+   * Supports a hardcoded set of default FitNotes activities. A user-provided map complements this.
+   *
+   * @param userMap: User-provided mapping from FitNotes activity name to FIT activity name.
+   * @return List<Activity>
+   * @throws Exception
+   */
+  public FitNotesParser (Map<String, String> userMap) throws Exception {
+    this.exercise_to_fit_category_map = getHardcodedMap();
+    this.FITStringToFITIndices = buildFITStringToFITIndices();
+    
+    // The user-provided mapping maps from FitNotes name to FIT name.
+    // We need the tuple of (category_id, exercise_id) instead of the FIT name.
+    if (userMap != null){
+      for (Map.Entry<String,String> entry : userMap.entrySet()) {
+        String FitNotesName = entry.getKey();
+        String FITName = entry.getValue();
+        int[] idTuple = FITStringToFITIndices.get(FITName);
+        this.exercise_to_fit_category_map.put(FitNotesName, idTuple);
+      }
+    }
   }
 
-  public Map<String, int[]> EXERCISE_TO_FIT_CATEGORY_MAP;
-    {
-      Map<String, int[]> tempMap = new HashMap<>();
-        tempMap.put( "Flat Barbell Bench Press",      new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.BARBELL_BENCH_PRESS } );
-        tempMap.put( "EZ-Bar Curl",                   new int[]{ ExerciseCategory.CURL, CurlExerciseName.STANDING_EZ_BAR_BICEPS_CURL } );
-        tempMap.put( "Overhead Press",                new int[]{ ExerciseCategory.SHOULDER_PRESS, ShoulderPressExerciseName.OVERHEAD_BARBELL_PRESS } );
-        tempMap.put( "Cable Crunch",                  new int[]{ ExerciseCategory.CRUNCH, CrunchExerciseName.CABLE_CRUNCH } );
-        tempMap.put( "EZ-Bar Skullcrusher",           new int[]{ ExerciseCategory.TRICEPS_EXTENSION, TricepsExtensionExerciseName.LYING_EZ_BAR_TRICEPS_EXTENSION } );
-        tempMap.put( "Lat Pulldown",                  new int[]{ ExerciseCategory.PULL_UP, PullUpExerciseName.LAT_PULLDOWN } );
-        tempMap.put( "Lateral Dumbbell Raise",        new int[]{ ExerciseCategory.LATERAL_RAISE, LateralRaiseExerciseName.LEANING_DUMBBELL_LATERAL_RAISE } );
-        tempMap.put( "Dumbbell Row",                  new int[]{ ExerciseCategory.ROW, RowExerciseName.DUMBBELL_ROW } );
-        tempMap.put( "Dumbbell Curl",                 new int[]{ ExerciseCategory.CURL, CurlExerciseName.DUMBBELL_BICEPS_CURL_WITH_STATIC_HOLD } );
-        tempMap.put( "Dumbbell Skullcrusher",         new int[]{ ExerciseCategory.TRICEPS_EXTENSION, TricepsExtensionExerciseName.DUMBBELL_LYING_TRICEPS_EXTENSION } );
-        tempMap.put( "Flat Dumbbell Fly",             new int[]{ ExerciseCategory.FLYE, FlyeExerciseName.DUMBBELL_FLYE } );
-        tempMap.put( "Incline Dumbbell Bench Press",  new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.INCLINE_DUMBBELL_BENCH_PRESS } );
-        tempMap.put( "Barbell Glute Bridge",          new int[]{ ExerciseCategory.HIP_RAISE, HipRaiseExerciseName.BARBELL_HIP_THRUST_ON_FLOOR } );
-        tempMap.put( "Romanian Deadlift",             new int[]{ ExerciseCategory.DEADLIFT, DeadliftExerciseName.BARBELL_STRAIGHT_LEG_DEADLIFT } );
-        tempMap.put( "Barbell Row",                   new int[]{ ExerciseCategory.ROW, RowExerciseName.REVERSE_GRIP_BARBELL_ROW } );
-        tempMap.put( "Bulgarian Split Squat",         new int[]{ ExerciseCategory.LUNGE, LungeExerciseName.DUMBBELL_BULGARIAN_SPLIT_SQUAT } );
-        tempMap.put( "Deadlift",                      new int[]{ ExerciseCategory.DEADLIFT, DeadliftExerciseName.BARBELL_DEADLIFT } );
-        tempMap.put( "Seated Dumbbell Press",         new int[]{ ExerciseCategory.SHOULDER_PRESS, ShoulderPressExerciseName.OVERHEAD_DUMBBELL_PRESS } );
-        tempMap.put( "Barbell Curl",                  new int[]{ ExerciseCategory.CURL, CurlExerciseName.BARBELL_BICEPS_CURL } );
-        tempMap.put( "Barbell Squat",                 new int[]{ ExerciseCategory.SQUAT, SquatExerciseName.BARBELL_BACK_SQUAT } );
-        tempMap.put( "One-legged Hip Thrust",         new int[]{ ExerciseCategory.HIP_RAISE, HipRaiseExerciseName.WEIGHTED_BRIDGE_WITH_LEG_EXTENSION } );
-        tempMap.put( "Front Dumbbell Raise",          new int[]{ ExerciseCategory.LATERAL_RAISE, LateralRaiseExerciseName.FRONT_RAISE } );
-        tempMap.put( "Dumbbell Calf Raise",           new int[]{ ExerciseCategory.CALF_RAISE, CalfRaiseExerciseName.SINGLE_LEG_STANDING_DUMBBELL_CALF_RAISE } );
-        tempMap.put( "Dumbbell Lunges",               new int[]{ ExerciseCategory.LUNGE, LungeExerciseName.DUMBBELL_LUNGE } );
-        tempMap.put( "Side Lying External Rotation",  new int[]{ ExerciseCategory.SHOULDER_STABILITY, ShoulderStabilityExerciseName.LYING_EXTERNAL_ROTATION } );
-        tempMap.put( "Full Can Exercise",             new int[]{ ExerciseCategory.SHOULDER_STABILITY, ShoulderStabilityExerciseName.STANDING_L_RAISE } );
-        tempMap.put( "Flat Dumbbell Bench Press",     new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.DUMBBELL_BENCH_PRESS } );
-        tempMap.put( "Russian Twist",                 new int[]{ ExerciseCategory.CORE, CoreExerciseName.RUSSIAN_TWIST } );
-        tempMap.put( "Concentration Curl",            new int[]{ ExerciseCategory.CURL, CurlExerciseName.SEATED_DUMBBELL_BICEPS_CURL } );
+  public ArrayList<String> getAllPossibleExercises(){
+    ArrayList<String> FITActivityNames = new ArrayList<String>(FITStringToFITIndices.keySet());
+    Collections.sort(FITActivityNames);
+    return FITActivityNames;
+  }
 
-        EXERCISE_TO_FIT_CATEGORY_MAP = tempMap ;
+
+  private Map<String,int[]> getHardcodedMap(){
+    Map<String, int[]> tempMap = new HashMap<>();
+    tempMap.put( "Flat Barbell Bench Press",      new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.BARBELL_BENCH_PRESS } );
+    tempMap.put( "EZ-Bar Curl",                   new int[]{ ExerciseCategory.CURL, CurlExerciseName.STANDING_EZ_BAR_BICEPS_CURL } );
+    tempMap.put( "Overhead Press",                new int[]{ ExerciseCategory.SHOULDER_PRESS, ShoulderPressExerciseName.OVERHEAD_BARBELL_PRESS } );
+    tempMap.put( "Cable Crunch",                  new int[]{ ExerciseCategory.CRUNCH, CrunchExerciseName.CABLE_CRUNCH } );
+    tempMap.put( "EZ-Bar Skullcrusher",           new int[]{ ExerciseCategory.TRICEPS_EXTENSION, TricepsExtensionExerciseName.LYING_EZ_BAR_TRICEPS_EXTENSION } );
+    tempMap.put( "Lat Pulldown",                  new int[]{ ExerciseCategory.PULL_UP, PullUpExerciseName.LAT_PULLDOWN } );
+    tempMap.put( "Lateral Dumbbell Raise",        new int[]{ ExerciseCategory.LATERAL_RAISE, LateralRaiseExerciseName.LEANING_DUMBBELL_LATERAL_RAISE } );
+    tempMap.put( "Dumbbell Row",                  new int[]{ ExerciseCategory.ROW, RowExerciseName.DUMBBELL_ROW } );
+    tempMap.put( "Dumbbell Curl",                 new int[]{ ExerciseCategory.CURL, CurlExerciseName.DUMBBELL_BICEPS_CURL_WITH_STATIC_HOLD } );
+    tempMap.put( "Dumbbell Skullcrusher",         new int[]{ ExerciseCategory.TRICEPS_EXTENSION, TricepsExtensionExerciseName.DUMBBELL_LYING_TRICEPS_EXTENSION } );
+    tempMap.put( "Flat Dumbbell Fly",             new int[]{ ExerciseCategory.FLYE, FlyeExerciseName.DUMBBELL_FLYE } );
+    tempMap.put( "Incline Dumbbell Bench Press",  new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.INCLINE_DUMBBELL_BENCH_PRESS } );
+    tempMap.put( "Barbell Glute Bridge",          new int[]{ ExerciseCategory.HIP_RAISE, HipRaiseExerciseName.BARBELL_HIP_THRUST_ON_FLOOR } );
+    tempMap.put( "Romanian Deadlift",             new int[]{ ExerciseCategory.DEADLIFT, DeadliftExerciseName.BARBELL_STRAIGHT_LEG_DEADLIFT } );
+    tempMap.put( "Barbell Row",                   new int[]{ ExerciseCategory.ROW, RowExerciseName.REVERSE_GRIP_BARBELL_ROW } );
+    tempMap.put( "Bulgarian Split Squat",         new int[]{ ExerciseCategory.LUNGE, LungeExerciseName.DUMBBELL_BULGARIAN_SPLIT_SQUAT } );
+    tempMap.put( "Deadlift",                      new int[]{ ExerciseCategory.DEADLIFT, DeadliftExerciseName.BARBELL_DEADLIFT } );
+    tempMap.put( "Seated Dumbbell Press",         new int[]{ ExerciseCategory.SHOULDER_PRESS, ShoulderPressExerciseName.OVERHEAD_DUMBBELL_PRESS } );
+    tempMap.put( "Barbell Curl",                  new int[]{ ExerciseCategory.CURL, CurlExerciseName.BARBELL_BICEPS_CURL } );
+    tempMap.put( "Barbell Squat",                 new int[]{ ExerciseCategory.SQUAT, SquatExerciseName.BARBELL_BACK_SQUAT } );
+    tempMap.put( "One-legged Hip Thrust",         new int[]{ ExerciseCategory.HIP_RAISE, HipRaiseExerciseName.WEIGHTED_BRIDGE_WITH_LEG_EXTENSION } );
+    tempMap.put( "Front Dumbbell Raise",          new int[]{ ExerciseCategory.LATERAL_RAISE, LateralRaiseExerciseName.FRONT_RAISE } );
+    tempMap.put( "Dumbbell Calf Raise",           new int[]{ ExerciseCategory.CALF_RAISE, CalfRaiseExerciseName.SINGLE_LEG_STANDING_DUMBBELL_CALF_RAISE } );
+    tempMap.put( "Dumbbell Lunges",               new int[]{ ExerciseCategory.LUNGE, LungeExerciseName.DUMBBELL_LUNGE } );
+    tempMap.put( "Side Lying External Rotation",  new int[]{ ExerciseCategory.SHOULDER_STABILITY, ShoulderStabilityExerciseName.LYING_EXTERNAL_ROTATION } );
+    tempMap.put( "Full Can Exercise",             new int[]{ ExerciseCategory.SHOULDER_STABILITY, ShoulderStabilityExerciseName.STANDING_L_RAISE } );
+    tempMap.put( "Flat Dumbbell Bench Press",     new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.DUMBBELL_BENCH_PRESS } );
+    tempMap.put( "Russian Twist",                 new int[]{ ExerciseCategory.CORE, CoreExerciseName.RUSSIAN_TWIST } );
+    tempMap.put( "Concentration Curl",            new int[]{ ExerciseCategory.CURL, CurlExerciseName.SEATED_DUMBBELL_BICEPS_CURL } );
+    return tempMap;
+  }
+
+  private Map<String, int[]> buildFITStringToFITIndices() throws Exception{
+    // Build a map from the string version of the FIT exercise name to a tuple of CategoryID, ExerciseNameID
+
+    Map<Integer, Class<?>> classMap = new HashMap<>();
+    classMap.put(0, BenchPressExerciseName.class);
+    classMap.put(1, CalfRaiseExerciseName.class);
+    classMap.put(2, CardioExerciseName.class);
+    classMap.put(3, CarryExerciseName.class);
+    classMap.put(4, ChopExerciseName.class);
+    classMap.put(5, CoreExerciseName.class);
+    classMap.put(6, CrunchExerciseName.class);
+    classMap.put(7, CurlExerciseName.class);
+    classMap.put(8, DeadliftExerciseName.class);
+    classMap.put(9, FlyeExerciseName.class);
+    classMap.put(10, HipRaiseExerciseName.class);
+    classMap.put(11, HipStabilityExerciseName.class);
+    classMap.put(12, HipSwingExerciseName.class);
+    classMap.put(13, HyperextensionExerciseName.class);
+    classMap.put(14, LateralRaiseExerciseName.class);
+    classMap.put(15, LegCurlExerciseName.class);
+    classMap.put(16, LegRaiseExerciseName.class);
+    classMap.put(17, LungeExerciseName.class);
+    classMap.put(18, OlympicLiftExerciseName.class);
+    classMap.put(19, PlankExerciseName.class);
+    classMap.put(20, PlyoExerciseName.class);
+    classMap.put(21, PullUpExerciseName.class);
+    classMap.put(22, PushUpExerciseName.class);
+    classMap.put(23, RowExerciseName.class);
+    classMap.put(24, ShoulderPressExerciseName.class);
+    classMap.put(25, ShoulderStabilityExerciseName.class);
+    classMap.put(26, ShrugExerciseName.class);
+    classMap.put(27, SitUpExerciseName.class);
+    classMap.put(28, SquatExerciseName.class);
+    classMap.put(29, TotalBodyExerciseName.class);
+    classMap.put(30, TricepsExtensionExerciseName.class);
+    classMap.put(31, WarmUpExerciseName.class);
+    classMap.put(32, RunExerciseName.class);
+
+    Map<String, int[]> map = new HashMap<>();
+
+    String categoryName = "";
+    for(int categoryID = 0; true; categoryID++){
+      categoryName = ExerciseCategory.getStringFromValue(categoryID);
+      if ("".equals(categoryName)){
+        break;
+      }
+      for(int exerciseID = 0; true; exerciseID++){
+        Class<?> exerciseNameClass = classMap.get(categoryID);
+        Method method = exerciseNameClass.getMethod("getStringFromValue", Integer.class);
+        String exerciseName = String.valueOf(method.invoke(null, exerciseID));
+        if ("".equals(exerciseName)){
+          break;
+        }
+        map.put(exerciseName, new int[]{categoryID, exerciseID} );
+      }
     }
+    return map;
+  }
 
 
   /**
@@ -149,12 +256,12 @@ public class FitNotesParser {
    * @return ActivitySet
    */
   public ActivitySet convertFromFitNotesSet(FitNotesSet fitNotesSet) {
-    if (!EXERCISE_TO_FIT_CATEGORY_MAP.containsKey(fitNotesSet.getExercise())) {
+    if (!this.exercise_to_fit_category_map.containsKey(fitNotesSet.getExercise())) {
       System.out.println("[FitNotesParser][convertFromFitNotesSet] Didn't find mapping for exercise " + fitNotesSet.getExercise());
       return null;
     }
     ActivitySet result = new ActivitySet();
-    int[] exCategorySubcategory = EXERCISE_TO_FIT_CATEGORY_MAP.get(fitNotesSet.getExercise());
+    int[] exCategorySubcategory = this.exercise_to_fit_category_map.get(fitNotesSet.getExercise());
 
     result.setCategory(exCategorySubcategory[0]);
     result.setSubCategory(exCategorySubcategory[1]);

--- a/src/main/java/com/developination/fitnotes2fit/FitNotesParser/FitNotesParser.java
+++ b/src/main/java/com/developination/fitnotes2fit/FitNotesParser/FitNotesParser.java
@@ -5,7 +5,6 @@ import java.io.FileReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +35,11 @@ import com.opencsv.bean.CsvToBeanBuilder;
 
 public class FitNotesParser {
 
-  public static Map<String, int[]> EXERCISE_TO_FIT_CATEGORY_MAP;
-    static {
+  public FitNotesParser () {
+  }
+
+  public Map<String, int[]> EXERCISE_TO_FIT_CATEGORY_MAP;
+    {
       Map<String, int[]> tempMap = new HashMap<>();
         tempMap.put( "Flat Barbell Bench Press",      new int[]{ ExerciseCategory.BENCH_PRESS, BenchPressExerciseName.BARBELL_BENCH_PRESS } );
         tempMap.put( "EZ-Bar Curl",                   new int[]{ ExerciseCategory.CURL, CurlExerciseName.STANDING_EZ_BAR_BICEPS_CURL } );
@@ -69,7 +71,7 @@ public class FitNotesParser {
         tempMap.put( "Russian Twist",                 new int[]{ ExerciseCategory.CORE, CoreExerciseName.RUSSIAN_TWIST } );
         tempMap.put( "Concentration Curl",            new int[]{ ExerciseCategory.CURL, CurlExerciseName.SEATED_DUMBBELL_BICEPS_CURL } );
 
-        EXERCISE_TO_FIT_CATEGORY_MAP = Collections.unmodifiableMap( tempMap );
+        EXERCISE_TO_FIT_CATEGORY_MAP = tempMap ;
     }
 
 
@@ -80,7 +82,7 @@ public class FitNotesParser {
    * @return List<Activity>
    * @throws Exception
    */
-  public static List<Activity> parseFileNotesIntoActivities(String filepath) throws Exception {
+  public List<Activity> parseFileNotesIntoActivities(String filepath) throws Exception {
     List<Activity> result = new ArrayList<>();
     List<FitNotesSet> setsList = readFileNotesSets(filepath);
     Map<String, List<ActivitySet>> mapDateToSets = new HashMap<>();
@@ -113,7 +115,7 @@ public class FitNotesParser {
    * @return List<Activity>
    * @throws Exception
    */
-  public static List<Activity> parseFileNotesIntoActivities(byte[] fileContent) throws Exception {
+  public List<Activity> parseFileNotesIntoActivities(byte[] fileContent) throws Exception {
     List<Activity> result = new ArrayList<>();
     List<FitNotesSet> setsList = readFileNotesSets(fileContent);
     Map<String, List<ActivitySet>> mapDateToSets = new HashMap<>();
@@ -146,7 +148,7 @@ public class FitNotesParser {
    * @param fitNotesSet
    * @return ActivitySet
    */
-  public static ActivitySet convertFromFitNotesSet(FitNotesSet fitNotesSet) {
+  public ActivitySet convertFromFitNotesSet(FitNotesSet fitNotesSet) {
     if (!EXERCISE_TO_FIT_CATEGORY_MAP.containsKey(fitNotesSet.getExercise())) {
       System.out.println("[FitNotesParser][convertFromFitNotesSet] Didn't find mapping for exercise " + fitNotesSet.getExercise());
       return null;

--- a/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
+++ b/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
@@ -59,7 +59,8 @@ public class Convert implements Runnable {
 
     System.out.println( "On it!" );
     try {
-        List<Activity> activityList = FitNotesParser.parseFileNotesIntoActivities(file);
+        FitNotesParser parser = new FitNotesParser();
+        List<Activity> activityList = parser.parseFileNotesIntoActivities(file);
         for (Activity activity : activityList) {
             System.out.println("[main] Starting to encode activity: " + activity.getActivityName());
             ActivityEncoder encoder = new ActivityEncoder(activity, avgHeartRate, avgRestTime);

--- a/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
+++ b/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
@@ -60,6 +60,9 @@ public class Convert implements Runnable {
         e.printStackTrace();
       }
     }
+    else if (this.avgHeartRate == -1){
+      this.avgHeartRate = 0;
+    }
     System.out.printf("Average Heart-rate=%s%n", this.avgHeartRate);
 
     if (this.avgRestTime == 0) {
@@ -71,6 +74,9 @@ public class Convert implements Runnable {
       } catch (Exception e) {
         e.printStackTrace();
       }
+    }
+    else if (this.avgRestTime == -1){
+      this.avgRestTime = 0;
     }
     System.out.printf("Average Rest time=%s%n", this.avgRestTime);
 

--- a/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
+++ b/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
@@ -1,6 +1,7 @@
 package com.developination.fitnotes2fit.controllers;
 
 import java.util.List;
+import java.util.Map;
 
 import com.developination.fitnotes2fit.ActivityEncoder.ActivityEncoder;
 import com.developination.fitnotes2fit.FitNotesParser.FitNotesParser;
@@ -29,6 +30,14 @@ public class Convert implements Runnable {
     description = "Average rest time between sets in minutes (e.g. 1.5). Don't think too hard on it, in the output it's randomised within plus-minus 1 minute. Same as for the heart-rate, this is useful when calculating Relative Effort and other metrics."
   )
   private float avgRestTime;
+  @Option(
+    names = {"--mapping", "-m"},
+    split = ",",
+    arity = "0..1",
+    interactive = true,
+    description = "Option to enable more exercises. Comma-separated pairs of <FitNotes_name>=<FIT_name>. Example: -m \"Flat Dumbbell Fly\"=DUMBBELL_FLYE,\"Pull Up\"=PULL_UP"
+  )
+  private Map<String, String> userMap;
 
   @Override
   public void run() {
@@ -59,7 +68,7 @@ public class Convert implements Runnable {
 
     System.out.println( "On it!" );
     try {
-        FitNotesParser parser = new FitNotesParser();
+        FitNotesParser parser = new FitNotesParser(userMap);
         List<Activity> activityList = parser.parseFileNotesIntoActivities(file);
         for (Activity activity : activityList) {
             System.out.println("[main] Starting to encode activity: " + activity.getActivityName());

--- a/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
+++ b/src/main/java/com/developination/fitnotes2fit/controllers/Convert.java
@@ -45,7 +45,7 @@ public class Convert implements Runnable {
     names = {"--strict", "-s"},
     description = "Set this flag to halt execution if any exercises can't be converted due to missing mappings."
   )
-  private Boolean strict;
+  private Boolean strict = false;
 
   @Override
   public void run() {

--- a/src/main/java/com/developination/fitnotes2fit/controllers/ListExercises.java
+++ b/src/main/java/com/developination/fitnotes2fit/controllers/ListExercises.java
@@ -1,0 +1,25 @@
+package com.developination.fitnotes2fit.controllers;
+
+import java.util.ArrayList;
+
+import com.developination.fitnotes2fit.FitNotesParser.FitNotesParser;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "list_exercises")
+public class ListExercises implements Runnable {
+  @Override
+  public void run() {
+    try {
+        FitNotesParser parser = new FitNotesParser(null);
+        ArrayList<String> exercises = parser.getAllPossibleExercises();
+
+        for (String FITExerciseName : exercises) {
+            System.out.println(FITExerciseName);
+        }
+    } catch (Exception e) {
+        e.printStackTrace();
+    }
+  }
+  
+}

--- a/src/main/java/com/developination/fitnotes2fit/fitnotes2fit.java
+++ b/src/main/java/com/developination/fitnotes2fit/fitnotes2fit.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import com.developination.fitnotes2fit.controllers.Convert;
+import com.developination.fitnotes2fit.controllers.ListExercises;
 import com.developination.fitnotes2fit.util.CLI;
 
 import picocli.CommandLine;
@@ -12,7 +13,8 @@ import picocli.CommandLine.Parameters;
 
 @Command(
     subcommands = {
-        Convert.class
+        Convert.class,
+        ListExercises.class
     }
 )
 public class fitnotes2fit implements Runnable {


### PR DESCRIPTION
- Custom activity mapping can be passed as a command line argument. The mapping is of the form `<Fitnotesname>=<FitName>` where the list of possible Fit exercise names is compiled by iterating through all the exercises in the Fit API.
- New command 'list_exercises' that spits out all possible Fit exercise names.
- Minor code refactor to reduce duplicate code
- Option to pass  -1 for heart rate or rest time to skip interactive prompts
- Added `--strict` flag that will not produce any output if something can't be mapped  